### PR TITLE
Updates ctrl+enter checks for TextInput

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2668,7 +2668,7 @@ export class TextInput extends Input {
         input.oninput = () => { this.valueChanged(); }
         input.onkeypress = (e: KeyboardEvent) => {
             // Ctrl+Enter pressed
-            if (e.keyCode == 10 && this.inlineAction) {
+            if (e.ctrlKey && e.charCode == 13 && this.inlineAction) {
                 this.inlineAction.execute();
             }
         }


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/4575

## Description
This ensures that the keyboard shortcut of `Ctrl+Enter` works when an inlineAction is assigned to a `Text.Input`

## How Verified
I have been writing my own control to display in adaptive code and it works there, so figured I'd bring across the change to here too.
